### PR TITLE
Improve README workflow docs and Flathub store description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,40 +4,78 @@ research trials, and patients.
 
 # Flatpak: Contributing Updates to Flathub
 
-This repository follows the Flathub contribution workflow using pull requests (PRs). All changes
-must be submitted as PRs and will be automatically built and tested by Flathub's CI system.
+This repository follows the Flathub contribution workflow. Every change is submitted as a pull
+request (PR), automatically built and tested by Flathub's CI, verified from a temporary test
+repository, and only then merged to publish the new version.
+
+## Workflow Overview
+
+1. **Open a PR** with your changes.
+2. **Flathub CI builds it.** The `flathubbot` posts the build status on the PR and, on success,
+   a command to install the build from the testing repository.
+3. **Test the build** locally using that command (see [Testing a PR build](#testing-a-pr-build)).
+4. **Merge** once the build succeeds and the app works as expected. Merging to the default branch
+   triggers publication of the new version to the stable Flathub repository.
 
 ## Making Changes
 
-1. Fork this repository
-2. Create a new branch for your changes
+1. Fork this repository (or create a branch if you have push access).
+2. Create a new branch for your changes.
 3. Update the necessary files:
-    - Update version numbers and dependencies in `io.github.nroduit.Weasis.yaml`
-    - Add new release information in `io.github.nroduit.Weasis.metainfo.xml`, e.g.:
+    - Bump the version, source URLs, and `sha256` checksums in `io.github.nroduit.Weasis.yaml`
+      (the Weasis `weasis-native.zip` and the bundled Temurin JDK for each architecture).
+    - Add a new release entry at the top of the `<releases>` list in
+      `io.github.nroduit.Weasis.metainfo.xml`, e.g.:
    ```xml
-   <release version="4.0.0-RC" date="2022-04-24">
-     <description>https://github.com/nroduit/Weasis/releases/tag/v4.0.0-rc</description>
+   <release version="4.7.0" date="2026-05-28">
+     <url type="details">https://github.com/nroduit/Weasis/releases/tag/v4.7.0</url>
    </release>
    ```
-4. Create a pull request to the main branch
+4. Open a pull request to the default branch.
 
-## Local Testing (Optional)
+## Testing a PR build
 
-If you want to test your changes locally before submitting a PR:
+When the build succeeds, `flathubbot` comments on the PR with a ready-to-use install command
+pointing at the testing repository. It looks like this (the build ID changes per build):
+
+```bash
+flatpak install --user https://dl.flathub.org/build-repo/<BUILD_ID>/io.github.nroduit.Weasis.flatpakref
+```
+
+Run that command, launch the app, and confirm the update behaves as expected. The build is
+produced for both `aarch64` and `x86_64`. When you are done testing, you can remove it with:
+
+```bash
+flatpak uninstall --user io.github.nroduit.Weasis
+```
+
+## Merging and Publishing
+
+Once the CI build is green and the test build works, merge the PR. Publication to the stable
+Flathub repository happens automatically after the merge; it may take a while before the new
+version is available to all users.
+
+## Local Build (Optional)
+
+You can also build the manifest locally before opening a PR.
 
 ### Prerequisites
 
 - Flatpak and Flatpak Builder
-- Flathub remote repository
+- The Flathub remote
 
 ### Install Build Tools
 
-On Debian-based systems, you can install Flatpak Builder with:
+On Debian-based systems:
 ```bash
 sudo apt install flatpak-builder
-```
-```bash
 flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 ```
 
-See [building documentation](https://docs.flatpak.org/en/latest/building.html)
+### Build and Install
+
+```bash
+flatpak-builder --user --install --force-clean build-dir io.github.nroduit.Weasis.yaml
+```
+
+See the [building documentation](https://docs.flatpak.org/en/latest/building.html) for details.

--- a/io.github.nroduit.Weasis.metainfo.xml
+++ b/io.github.nroduit.Weasis.metainfo.xml
@@ -12,21 +12,45 @@
   </categories>
   <description>
     <p>
-      Weasis is a standalone and web-based software for visualizing images obtained from medical imaging devices. 
-      This free DICOM viewer is used in healthcare by hospitals, health networks, multicenter research trials, and patients.
+      An open-source DICOM viewer for standalone and web use, built for medical image
+      visualization in PACS and DICOM workflows — from routine reading to AI-assisted
+      review and quantitative imaging. It is used in healthcare by hospitals, health
+      networks, multicenter research trials, and patients.
     </p>
-    <p>General Features:</p>
+    <p>General features:</p>
     <ul>
-      <li>Flexible integration with PACS, VNA, RIS, HIS, or PHR</li>
-      <li>Responsive user interface and work well on high DPI screens</li>
-      <li>Web access through weasis protocol</li>
-      <li>Multi-language support</li>
-      <li>DICOM Send (storeSCU and STOW-RS)</li>
-      <li>DICOM Query/Retrieve (C-GET, C-MOVE and WADO-URI) and DICOMWeb (QUERY and RETRIEVE)</li>
-      <li>Dicomizer module (allow importing standard images and convert them in DICOM)</li>
-      <li>Embedded DICOM viewer in CD/DVD or other portable media</li>
+      <li>Open source under the EPL 2.0 or Apache 2.0 license</li>
+      <li>Integrates with PACS, VNA, RIS, HIS, or EHR</li>
+      <li>Desktop builds for Windows, macOS, and Linux; web access via the <code>weasis://</code> protocol</li>
+      <li>Responsive UI for high-DPI screens, with support for over 20 languages</li>
+      <li>Server- and client-side preference configuration with multi-level overrides</li>
+      <li>API for custom plug-ins; embeddable viewer for CD/DVD or portable media</li>
+      <li>The <em>Dicomizer</em> module converts images, videos, PDFs, and STL meshes into DICOM</li>
+      <li>AI-assisted and quantitative imaging workflows</li>
     </ul>
-    <p>Viewer Features (see Tutorials from Help link below)</p>
+    <p>Connectivity and interoperability:</p>
+    <p>
+      Weasis fits existing clinical infrastructure two ways: server-side via a gateway such
+      as ViewerHub (centralized brokering of PACS/DICOMweb, authentication, and manifests),
+      or client-side by configuring DICOM nodes and DICOMweb sources directly.
+    </p>
+    <ul>
+      <li><em>Classic DIMSE</em> — Query/Retrieve (C-FIND, C-GET, C-MOVE) and Store (C-STORE)</li>
+      <li><em>DICOMweb</em> — QIDO-RS, WADO-RS, and STOW-RS over HTTPS</li>
+      <li><em>WADO-URI</em> — for legacy PACS and the Weasis manifest flow</li>
+      <li><em>weasis:// protocol</em> — single-click launch from browsers, EHR, and RIS portals</li>
+      <li><em>Authentication</em> — Basic, OAuth 2.0, and OpenID Connect (Auth Code with PKCE, RFC 8252); works with Keycloak, Google Cloud Healthcare, or any OIDC provider</li>
+      <li><em>Send and export</em> — store to PACS or DICOMweb, or export locally as DICOMDIR ZIP, ISO with embedded viewer, JPEG, PNG, TIFF, AVI, or MP4</li>
+    </ul>
+    <p>Viewer features:</p>
+    <ul>
+      <li>Broad data-type support, including multi-frame, <em>Enhanced</em> CT/MR/US volumes, MPEG-2/4, SR, PR, KOS, SEG, RT, ECG, and Parametric Map; codecs include JPEG (baseline, extended, lossless), JPEG-LS, JPEG 2000, JPEG-XL, and RLE</li>
+      <li>Multi-monitor viewing with per-monitor calibration, HiDPI, and full-screen; customizable mouse and keyboard controls; Modality/VOI/Presentation LUTs and GSPS overlays</li>
+      <li>Advanced imaging: oblique MPR with gantry-tilt correction, MIP, 3D volume rendering with segmentation overlay, 4D/multi-phase splitting, cross-lines, 3D cursor, and side-by-side comparison layouts</li>
+      <li>Measurement and annotation: length, area, angle (including Cobb), free-shape, pixel-region statistics, histograms, and SUV measurement for PET/nuclear imaging</li>
+      <li>Dedicated viewers for ECG waveforms, structured reports (SR), audio (AU), and radiotherapy (RT structure set, dose, DVH)</li>
+      <li>Printing to DICOM and system printers, Key Object Selection, full DICOM attribute display and search, and <em>Acquire/Dicomizer</em> capture of non-DICOM media</li>
+    </ul>
   </description>
   <launchable type="desktop-id">io.github.nroduit.Weasis.desktop</launchable>
   <branding>

--- a/io.github.nroduit.Weasis.metainfo.xml
+++ b/io.github.nroduit.Weasis.metainfo.xml
@@ -50,12 +50,16 @@
   </branding>
   <screenshots>
     <screenshot type="default">
-      <image>https://user-images.githubusercontent.com/993975/153709915-c352738e-3d51-4f12-bf12-7c3435c1b04a.PNG</image>
-      <caption>Main DICOM viewer interface showing medical image visualization</caption>
+      <image>https://raw.githubusercontent.com/nroduit/Weasis/v4.7.0/weasis.jpg</image>
+      <caption>Multiplanar reconstruction and 3D volume rendering of a CT study</caption>
     </screenshot>
     <screenshot>
-      <image>https://weasis.org/gallery1/Orthogonal%20Multiplanar%20Reconstruction_hu_f7ff19e7f1deaca8.jpg</image>
-      <caption>Orthogonal Multiplanar Reconstruction view for 3D medical imaging</caption>
+      <video container="webm" codec="vp9" width="1280" height="720">https://weasis.org/videos/weasis-demo.webm</video>
+      <caption>Overview of the Weasis DICOM viewer</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://user-images.githubusercontent.com/993975/153709915-c352738e-3d51-4f12-bf12-7c3435c1b04a.PNG</image>
+      <caption>Main DICOM viewer interface showing medical image visualization</caption>
     </screenshot>
     <screenshot>
       <image>https://weasis.org/gallery2/Dicomizer_hu_45cdc783797831e6.jpg</image>

--- a/io.github.nroduit.Weasis.metainfo.xml
+++ b/io.github.nroduit.Weasis.metainfo.xml
@@ -14,42 +14,33 @@
     <p>
       An open-source DICOM viewer for standalone and web use, built for medical image
       visualization in PACS and DICOM workflows — from routine reading to AI-assisted
-      review and quantitative imaging. It is used in healthcare by hospitals, health
-      networks, multicenter research trials, and patients.
+      review and quantitative imaging. It is used by hospitals, health networks,
+      multicenter research trials, and patients.
     </p>
     <p>General features:</p>
     <ul>
       <li>Open source under the EPL 2.0 or Apache 2.0 license</li>
       <li>Integrates with PACS, VNA, RIS, HIS, or EHR</li>
-      <li>Desktop builds for Windows, macOS, and Linux; web access via the <code>weasis://</code> protocol</li>
+      <li>Desktop builds for Windows, macOS, and Linux; web launch via the <code>weasis://</code> protocol</li>
       <li>Responsive UI for high-DPI screens, with support for over 20 languages</li>
-      <li>Server- and client-side preference configuration with multi-level overrides</li>
+      <li>Server- and client-side configuration with multi-level overrides</li>
       <li>API for custom plug-ins; embeddable viewer for CD/DVD or portable media</li>
       <li>The <em>Dicomizer</em> module converts images, videos, PDFs, and STL meshes into DICOM</li>
-      <li>AI-assisted and quantitative imaging workflows</li>
     </ul>
     <p>Connectivity and interoperability:</p>
-    <p>
-      Weasis fits existing clinical infrastructure two ways: server-side via a gateway such
-      as ViewerHub (centralized brokering of PACS/DICOMweb, authentication, and manifests),
-      or client-side by configuring DICOM nodes and DICOMweb sources directly.
-    </p>
     <ul>
-      <li><em>Classic DIMSE</em> — Query/Retrieve (C-FIND, C-GET, C-MOVE) and Store (C-STORE)</li>
-      <li><em>DICOMweb</em> — QIDO-RS, WADO-RS, and STOW-RS over HTTPS</li>
-      <li><em>WADO-URI</em> — for legacy PACS and the Weasis manifest flow</li>
-      <li><em>weasis:// protocol</em> — single-click launch from browsers, EHR, and RIS portals</li>
-      <li><em>Authentication</em> — Basic, OAuth 2.0, and OpenID Connect (Auth Code with PKCE, RFC 8252); works with Keycloak, Google Cloud Healthcare, or any OIDC provider</li>
-      <li><em>Send and export</em> — store to PACS or DICOMweb, or export locally as DICOMDIR ZIP, ISO with embedded viewer, JPEG, PNG, TIFF, AVI, or MP4</li>
+      <li>Classic DIMSE: Query/Retrieve (C-FIND, C-GET, C-MOVE) and Store (C-STORE)</li>
+      <li>DICOMweb (QIDO-RS, WADO-RS, STOW-RS) and WADO-URI for legacy PACS</li>
+      <li>Authentication via Basic, OAuth 2.0, and OpenID Connect, working with Keycloak, Google Cloud Healthcare, or any OIDC provider</li>
+      <li>Send to PACS or DICOMweb, or export locally as DICOMDIR ZIP, ISO with embedded viewer, or common image and video formats</li>
     </ul>
     <p>Viewer features:</p>
     <ul>
-      <li>Broad data-type support, including multi-frame, <em>Enhanced</em> CT/MR/US volumes, MPEG-2/4, SR, PR, KOS, SEG, RT, ECG, and Parametric Map; codecs include JPEG (baseline, extended, lossless), JPEG-LS, JPEG 2000, JPEG-XL, and RLE</li>
-      <li>Multi-monitor viewing with per-monitor calibration, HiDPI, and full-screen; customizable mouse and keyboard controls; Modality/VOI/Presentation LUTs and GSPS overlays</li>
-      <li>Advanced imaging: oblique MPR with gantry-tilt correction, MIP, 3D volume rendering with segmentation overlay, 4D/multi-phase splitting, cross-lines, 3D cursor, and side-by-side comparison layouts</li>
-      <li>Measurement and annotation: length, area, angle (including Cobb), free-shape, pixel-region statistics, histograms, and SUV measurement for PET/nuclear imaging</li>
+      <li>Broad data-type support, including multi-frame, <em>Enhanced</em> CT/MR/US volumes, SR, PR, KOS, SEG, RT, ECG, and Parametric Map, with the common DICOM codecs</li>
+      <li>Multi-monitor viewing with per-monitor calibration, HiDPI, and full-screen; customizable mouse and keyboard controls</li>
+      <li>Advanced imaging: oblique MPR, MIP, 3D volume rendering with segmentation overlay, 4D/multi-phase splitting, and side-by-side comparison layouts</li>
+      <li>Measurement and annotation, including length, area, angle (Cobb), pixel-region statistics, histograms, and SUV for PET/nuclear imaging</li>
       <li>Dedicated viewers for ECG waveforms, structured reports (SR), audio (AU), and radiotherapy (RT structure set, dose, DVH)</li>
-      <li>Printing to DICOM and system printers, Key Object Selection, full DICOM attribute display and search, and <em>Acquire/Dicomizer</em> capture of non-DICOM media</li>
     </ul>
   </description>
   <launchable type="desktop-id">io.github.nroduit.Weasis.desktop</launchable>


### PR DESCRIPTION
## Summary

Two presentation/documentation improvements:

**README** — document the workflow actually used today:
- Open a PR → Flathub CI builds it → `flathubbot` posts a test install command pointing at the testing repo (`flatpak install --user https://dl.flathub.org/build-repo/<BUILD_ID>/io.github.nroduit.Weasis.flatpakref`) → test → merge to publish.
- Fix the outdated `metainfo.xml` release example and add a local build command.

**Flathub store listing** (`metainfo.xml` `<description>`) — rewrite per Flathub guidelines:
- Convert markdown (bold, italics, inline links) to valid AppStream markup (`<em>`, `<code>`); links stay in `<url>` tags.
- Remove the dangling "see ... link below" reference and the unfinished trailing line.
- Avoid leading with the app name; add Connectivity & Interoperability and a fuller Viewer Features section, then trim for concision (~260 words).

## Test plan

- `appstreamcli validate --no-net io.github.nroduit.Weasis.metainfo.xml` → passes.
- Flathub CI test build can be used to preview the rendered store listing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)